### PR TITLE
Bug fixes for resting state recordings with extra channels or errors reading eog channels

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+.ipynb_checkpoints
+*/.ipynb_checkpoints/*
+
+*__pycache__/*
+*.pyc

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This library is a pythonic preprocessing and analysis library for EEG and simult
 This is currently research code under development by the Grosenick and Deisseroth labs. It will be released with full documentation for public use in 2025: for now, USE AT YOUR OWN RISK.
 
 ### Brief useage instructions
-After setting relevent analysis parameters in the 'test_config.cfg' configuration file, preprocessing can be run from the command line using 'python preprocessing.py'. 
+After setting relevant analysis parameters in the 'test_config.cfg' configuration file, preprocessing can be run from the command line using 'python preprocessing.py'. For batch preprocessing multiple recordings, set the data directory in 'preprocessing_client.py', then run 'python preprocessing_client.py'.
 
 ### Authors
 Sanweda Mahagabin (sam4044@med.cornell.edu)

--- a/preprocessing.py
+++ b/preprocessing.py
@@ -301,31 +301,37 @@ class Preprocessing(object):
             data_list = []
             for f in filenames:
                 raw = load_file(f)
+                print(f'Raw data shape: {raw._data.shape}')
 
-                print(f"{data_type} file: {f}, channels: {raw.info['nchan']}, sfreq: {raw.info['sfreq']}")
+                # Ensure channels match between recordings prior to concatenation --
+                # Some recordings may contain extra channels in ch_names list.
+                if len(data_list) == len(filenames):
+                    for i, raw in enumerate(data_list):
+                        print(f"{data_type} file: {f}, channels: {raw.info['nchan']}")
+                        if 'IBEG' in raw.ch_names or 'IEND' in raw.ch_names:
+                            raw.drop_channels(['IBEG', 'IEND'])
+                            if data_type == 'pre-treatment' or data_type == 'post-treatment':
+                                raw.drop_channels(['STI 014'])
+                                print(f"Modified channel list: {raw.info['nchan']}")
 
                 # If filtering separately, apply filters to each raw dataset before concatenation
                 if self.filter_raws_separately:
                     filtered_raw = apply_filtering(raw)
                     data_list.append(filtered_raw)
-                    if len(data_list) == len(filenames):
-                        for i, raw in enumerate(data_list):
-                            if 'IBEG' in raw.ch_names or 'IEND' in raw.ch_names:
-                                raw.drop_channels(['IBEG', 'IEND'])
-                                if data_type == 'pre-treatment' or data_type == 'post-treatment':
-                                    raw.drop_channels(['STI 014'])
-                                    print(f"Modified channel list: {raw.info['nchan']}, sfreq: {raw.info['sfreq']}")
 
+                    if len(data_list) == len(filenames):
                         data = mne.concatenate_raws(data_list.copy(), verbose='warning')
                     else:
+                        # If there is only one file for the given recording type, assign to data
                         data = filtered_raw
                 else:
-                    # No filtering yet, just append raw data to list and concatenate
+                    # Append raw of the given recording type (e.g. 'pre-treatment') to data_list
                     data_list.append(raw)
-                    # Concatenate raws of same recording type and filter together
+
+                    # Concatenate raws of the same recording type and filter together
                     if len(data_list) == len(filenames):
                         data = mne.concatenate_raws(data_list.copy(), verbose='warning')
-                        data = apply_filtering(raw)
+                        data = apply_filtering(data)
 
             try:
                 # Save the filtered data to raw MNE-Python file
@@ -343,7 +349,6 @@ class Preprocessing(object):
 
             except UnboundLocalError:
                 pipeline_log.error(co.color('red', 'UnboundLocalError: Verify config file input and results paths.'))
-
             return None
 
         self.data = {}
@@ -352,23 +357,31 @@ class Preprocessing(object):
         if self.data_types['resting_state']:
             if self.data_types['pre-treatment']:
                 filenames_pre = [f for f in os.listdir(self.input_path) if 'pre' in f.split('_')]
-                self.data['pre-treatment'] = filter_and_concatenate(filenames_pre, 'pre-treatment')
-                pipeline_log.info(f"Pre-treatment resting state data shape: {self.data['pre-treatment']._data.shape}")
-                save_psd(pjoin(self.results_savepath, 'psd_filtered_restingstate_pre.png'), self.data['pre-treatment'])
+                try:
+                    self.data['pre-treatment'] = filter_and_concatenate(filenames_pre, 'pre-treatment')
+                    pipeline_log.info(f"Pre-treatment resting state data shape: {self.data['pre-treatment']._data.shape}")
+                    save_psd(pjoin(self.results_savepath, 'psd_filtered_restingstate_pre.png'),
+                             self.data['pre-treatment'])
+                except AttributeError:
+                    pipeline_log.error(co.color('red', 'Cannot retrieve pre-treatment data.'))
+
             if self.data_types['post-treatment']:
                 filenames_post = [f for f in os.listdir(self.input_path) if 'post' in f.split('_')]
                 try:
                     self.data['post-treatment'] = filter_and_concatenate(filenames_post, 'post-treatment')
                     pipeline_log.info(f"Post-treatment resting state data shape: {self.data['post-treatment']._data.shape}")
-                    save_psd(pjoin(self.results_savepath, 'psd_filtered_restingstate_post.png'), self.data['post-treatment'])
+                    save_psd(pjoin(self.results_savepath, 'psd_filtered_restingstate_post.png'),
+                             self.data['post-treatment'])
                 except AttributeError:
                     pipeline_log.error(co.color('red', 'Cannot retrieve post-treatment data.'))
 
-        elif self.data_from_TMS or self.data_from_motor or self.data_from_fif:
-            filenames_other = [f for f in os.listdir(self.input_path) if 'treatment' in f]
-            self.data['other'] = filter_and_concatenate(filenames_other, 'other')
-            pipeline_log.info(f"Data shape: {self.data['other']._data.shape}")
-            save_psd(pjoin(self.results_savepath, 'psd_filtered.png'), self.data['other'])
+        # Data from rTMS-EEG and single-pulse TMS-EEG are currently not supported for preprocessing.
+        # TODO: add this functionality
+        # elif self.data_from_TMS or self.data_from_motor or self.data_from_fif:
+            # filenames_other = [f for f in os.listdir(self.input_path) if 'treatment' in f]
+            # self.data['other'] = filter_and_concatenate(filenames_other, 'other')
+            # pipeline_log.info(f"Data shape: {self.data['other']._data.shape}")
+            # save_psd(pjoin(self.results_savepath, 'psd_filtered.png'), self.data['other'])
 
         else:
             raise ValueError('Data type is misspecified or does not exist in the input folder.')
@@ -598,7 +611,6 @@ class Preprocessing(object):
 
         return data
 
-
     def _artifact_subspace_reconstruction(self, data, name):
         # Run ASR
         data_cleaned = artifact_subspace_reconstruction(data, cutoff=self.asr_cutoff)
@@ -693,6 +705,7 @@ def wICA(ica, ICs, levels=5, wavelet='coif5', normalize=False,
 
     return wICs, artifacts
 
+
 # ------------- ICA Label functions ------------- #
 def iclabel(mne_raw, num_components=20, keep=["brain"], method='infomax', fit_params=dict(extended=True), reject=None):
     '''
@@ -730,6 +743,7 @@ def iclabel(mne_raw, num_components=20, keep=["brain"], method='infomax', fit_pa
     print(f'Number of ICA components excluded: {len(exclude_idx)}')
     cleaned = ica.apply(mne_raw, exclude=exclude_idx, verbose=False)
     return ic_labels, ica, cleaned
+
 
 def autoreject_bad_segments(raw, segment_length=1.0, method='autoreject'):
     # generate epochs object from raw
@@ -836,7 +850,7 @@ def save_ica_components(save_file, ica, ic_label_obj=None):
         save_file: absolute path to save PNG output file.
         ica: an MNE-Python ica object.
         ic_label_list: optional list of conformal labels from ica_label to add to plot topomap titles.
-    
+
     '''
     num_components = ica.n_components
     if ic_label_obj is not None:
@@ -900,7 +914,7 @@ def save_eog_plot(name, save_file, mne_in, channel_list=['E32', 'E241', 'E25', '
     eog_epochs = mne.preprocessing.create_eog_epochs(mne_in, ch_name=channel_list)
 
     if len(eog_epochs.events) == 0:
-        eog_picks = mne_in.pick_channels(channel_list)
+        eog_picks = mne_in.copy().pick_channels(channel_list)  # Use copy of mne_in. pick_channels operates in place.
         eog_picks.plot(show=False)
         sns.despine()
         plt.savefig(save_file)

--- a/preprocessing.py
+++ b/preprocessing.py
@@ -22,7 +22,6 @@ import numpy as np
 import h5py
 import multiprocessing
 import scipy.io as io
-import matplotlib
 
 import matplotlib.pyplot as plt
 from sklearn.decomposition import FastICA
@@ -44,9 +43,6 @@ import util.console_output as co
 
 # Alias useful functions
 pjoin = os.path.join
-
-# Set backend
-matplotlib.use('Agg')
 
 # Set up the pipeline log.  It is configured in the constructor below,
 # but used by the free functions outside of the class, hence its        

--- a/preprocessing_client.py
+++ b/preprocessing_client.py
@@ -3,7 +3,7 @@ import re
 import configparser
 import subprocess
 
-to_preprocess_datapath = '/Users/Bella/Desktop/Grosenick_Lab/eeg_patient_data/mdd_dlpfc/to_preprocess'
+to_preprocess_datapath = '/Users/Bella/Desktop/Grosenick_Lab/eeg_patient_data/to_preprocess'
 
 
 # Takes a directory file path holding subject data that needs to be preprocessed

--- a/test_config.cfg
+++ b/test_config.cfg
@@ -1,6 +1,6 @@
 [paths]
-input_path = /Users/Bella/Desktop/Grosenick_Lab/eeg_patient_data/mdd_dlpfc/to_preprocess/subject25_m292_dlpfc_59/m292_dlpfc_day1
-results_path = /Users/Bella/Desktop/Grosenick_Lab/eeg_patient_data/mdd_dlpfc/to_preprocess/subject25_m292_dlpfc_59/m292_dlpfc_day1/Results
+input_path = /Users/Bella/Desktop/Grosenick_Lab/eeg_patient_data/mdd/subject40_m473_dlpfc_59/m473_dlpfc_day4
+results_path = /Users/Bella/Desktop/Grosenick_Lab/eeg_patient_data/mdd/subject40_m473_dlpfc_59/m473_dlpfc_day4/Results
 
 [general]
 mne_log_level = error
@@ -25,7 +25,7 @@ band_pass_high = 200.0
 filter_type = fir
 
 [resampling]
-resample = True
+resample = False
 resampling_rate = 250.0
 
 [cleaning]

--- a/test_config.cfg
+++ b/test_config.cfg
@@ -1,6 +1,6 @@
 [paths]
-input_path = /Users/Bella/Desktop/Grosenick_Lab/eeg_patient_data/mdd/subject40_m473_dlpfc_59/m473_dlpfc_day4
-results_path = /Users/Bella/Desktop/Grosenick_Lab/eeg_patient_data/mdd/subject40_m473_dlpfc_59/m473_dlpfc_day4/Results
+input_path = /Users/Bella/Desktop/Grosenick_Lab/eeg_patient_data/mdd/subject44_m468_dlpfc_57/m468_dlpfc_day4
+results_path = /Users/Bella/Desktop/Grosenick_Lab/eeg_patient_data/mdd/subject44_m468_dlpfc_57/m468_dlpfc_day4/Results
 
 [general]
 mne_log_level = error


### PR DESCRIPTION
Modified filter_and_concatenate to 1) allow concatenation of recordings with different channel lists (some recordings have extra channels) and 2) work with the config setting filter_raws_separately set to False. Fixed bug with save_eog_epochs function that caused overwriting of all channels with 4 EOG channels in some recordings.